### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ libc = "0.2.148"
 pretty_assertions = "1.4.0"
 rand = "0.8.5"
 ratatui = { version = "0.27.0", features = ["serde", "macros"] }
-rusqlite = "0.32.1"
+rusqlite = { version = "0.32.1", features = ["bundled"] }
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"
 signal-hook = "0.3.17"


### PR DESCRIPTION
Enabled bundled feature for rusqlite in Cargo.toml to solve cannot open input file 'sqlite3.lib' issue for windows users